### PR TITLE
added Firebase import for use of Timestamp object

### DIFF
--- a/FriendlyEats/Restaurant.swift
+++ b/FriendlyEats/Restaurant.swift
@@ -15,6 +15,7 @@
 //
 
 import Foundation
+import Firebase
 
 struct Restaurant {
 


### PR DESCRIPTION
This branch didn't compile for me until I added the `import Firebase` to Restaurant.swift, because of the  use of the `Timestamp` object. It appears this import is on the master branch, but never made it to the codelab-complete branch. 
Fixes #122 